### PR TITLE
fix wrong keyword argument in LLMLingua2.ipynb

### DIFF
--- a/examples/LLMLingua2.ipynb
+++ b/examples/LLMLingua2.ipynb
@@ -241,7 +241,7 @@
     "    \"stream\": False,\n",
     "}\n",
     "response = openai.ChatCompletion.create(\n",
-    "    engine=\"gpt-4-32k\",\n",
+    "    model=\"gpt-4-32k\",\n",
     "    **request_data,\n",
     ")\n",
     "print(json.dumps(response, indent=4))"


### PR DESCRIPTION
# What does this PR do?
Fixes a typo in `LLMLingua2.ipynb` example based on a change in the API


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).


## Who can review?
@SiyunZhao 
