### PR TITLE
Docs: correct default value of 'use_llmlingua2'

### DIFF
--- a/llmlingua/prompt_compressor.py
+++ b/llmlingua/prompt_compressor.py
@@ -51,7 +51,7 @@ class PromptCompressor:
         use_llmlingua2 (bool, optional): Whether to use llmlingua-2 compressor based on the paper
             "LLMLingua-2: Data Distillation for Efficient and Faithful Task-Agnostic Prompt Compression".
             Zhuoshi Pan, Qianhui Wu, Huiqiang Jiang, Menglin Xia, Xufang Luo, Jue Zhang, Qingwei Lin, Victor Ruhle, Yuqing Yang, Chin-Yew Lin, H. Vicky Zhao, Lili Qiu, Dongmei Zhang.
-            arXiv preprint arXiv:2403.2403.12968 (2024), Default is True.
+            arXiv preprint arXiv:2403.2403.12968 (2024), Default is False.
         llmlingua2_config (dict, optional): A dictionary containing the configuration parameters for llmlingua-2. Default is
             {
                 "max_batch_size": 50,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

The default argument for the 'use_llmlingua2' parameter is `False`, but the docstring is incorrectly written as `True`. The `DOCUMENT.md` file is correctly written as `False`.

https://github.com/microsoft/LLMLingua/blob/40ac969a82f162b3eb0b8e1f1416756d442e4eec/DOCUMENT.md?plain=1#L283

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
	- the document already describes it's default value is False:
		- https://github.com/microsoft/LLMLingua/blob/40ac969a82f162b3eb0b8e1f1416756d442e4eec/DOCUMENT.md?plain=1#L283
- [ ] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@iofu728 @mydmdm
