### PR TITLE
Fix prompts smaller than iterative_size not being compressed

### DIFF
--- a/llmlingua/prompt_compressor.py
+++ b/llmlingua/prompt_compressor.py
@@ -1413,6 +1413,8 @@ class PromptCompressor:
         self_input_ids=None,
         self_attention_mask=None,
     ):
+        if end < iterative_size:
+            end = iterative_size
         if self_loss is not None:
             need_idx = torch.concat(
                 [


### PR DESCRIPTION
# What does this PR do?

Fixes #196

Prompts smaller than `iterative_size / 2` were not compressed at all and only partially compressed if `> iterative_size / 2` and `< iterative_size`. This PR fixes this edge case. See the issue for more details.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
