### PR TITLE
Fix wrong key storage during filtering 

### DIFF
--- a/experiments/llmlingua2/data_collection/filter.py
+++ b/experiments/llmlingua2/data_collection/filter.py
@@ -66,7 +66,7 @@ for labels, origin, comp, retrieval, cr, vr, hr, mr, ag in zip(
     kept["labels"],
     kept["origin"],
     kept["comp"],
-    res_pt["retrieval"],
+    kept["retrieval"],
     kept["comp_rate"],
     kept["variation_rate"],
     kept["hitting_rate"],


### PR DESCRIPTION
# What does this PR do?

This PR modifies the code to store retrieval in `res_pt` instead of `kept`, addressing potential issues that could arise during data verification.

This change does not affect the training results directly, but resolves potential data verification issues by properly associating `retrieval` with `kept`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@iofu728 @QianhuiWu 
