### PR TITLE
Fix perplexity calculation and resulting overcompress…

### DIFF
--- a/llmlingua/prompt_compressor.py
+++ b/llmlingua/prompt_compressor.py
@@ -1702,14 +1702,19 @@ class PromptCompressor:
 
             for delta_end, ratio in iterative_ratios[idx]:
                 loss = past_loss
+                seg_end = end - iterative_size + delta_end + 1
+                if seg_end < iterative_size:
+                    seg_end = iterative_size
+                seg_start = seg_end - iterative_size
                 if condition_compare:
                     self_loss = self_past_loss
+                    self_seg_start, self_seg_end = seg_start - start, seg_end - start
                     threshold = self.get_estimate_threshold_base_distribution(
-                        self_loss[: loss[start:].shape[0]] - loss[start:], ratio, False
+                        self_loss[self_seg_start:self_seg_end] - loss[seg_start:seg_end], ratio, False
                     )
                 else:
                     threshold = self.get_estimate_threshold_base_distribution(
-                        loss, ratio, False
+                        loss[seg_start:seg_end], ratio, False
                     )
 
                 (


### PR DESCRIPTION
Fixes #195, #61

@iofu728 @XufangLuo

While perplexity is calculated on all previously compressed segments as well as the current segment, the quantile threshold for compression should be calculated only on the perplexity values for the current segment, otherwise the compression ratio is overshot for large prompts. See this comment for details: https://github.com/microsoft/LLMLingua/issues/61#issuecomment-2596068938

I did not run the tests as compression outputs will change and tests will fail, if a maintainer gives positive feedback on this change I will update the tests accordingly.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
